### PR TITLE
updated com.google.firebase.iid (deprecated) to com.google.firebase.i…

### DIFF
--- a/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
+++ b/src/android/com/gae/scaffolder/plugin/FCMPlugin.java
@@ -9,8 +9,8 @@ import com.gae.scaffolder.plugin.interfaces.*;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.installations.FirebaseInstallations;
+import com.google.firebase.installations.InstallationTokenResult;
 import com.google.firebase.messaging.FirebaseMessaging;
 
 import org.apache.cordova.CallbackContext;
@@ -179,9 +179,9 @@ public class FCMPlugin extends CordovaPlugin {
 
     public void getToken(final TokenListeners<String, JSONObject> callback) {
         try {
-            FirebaseInstanceId.getInstance().getInstanceId().addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+            FirebaseInstallations.getInstance().getToken(true).addOnCompleteListener(new OnCompleteListener<InstallationTokenResult>() {
                 @Override
-                public void onComplete(Task<InstanceIdResult> task) {
+                public void onComplete(Task<InstallationTokenResult> task) {
                     if (!task.isSuccessful()) {
                         Log.w(TAG, "getInstanceId failed", task.getException());
                         try {
@@ -201,7 +201,7 @@ public class FCMPlugin extends CordovaPlugin {
                 }
             });
 
-            FirebaseInstanceId.getInstance().getInstanceId().addOnFailureListener(new OnFailureListener() {
+            FirebaseInstallations.getInstance().getToken(true).addOnFailureListener(new OnFailureListener() {
                 @Override
                 public void onFailure(final Exception e) {
                     try {
@@ -224,7 +224,7 @@ public class FCMPlugin extends CordovaPlugin {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
-                    FirebaseInstanceId.getInstance().deleteInstanceId();
+                    FirebaseInstallations.getInstance().delete();
                     callbackContext.success();
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());


### PR DESCRIPTION
This fixes a build problem when the plugin is build against newer versions of ANDROID_FIREBASE_BOM_VERSION such as 30.0.0:

/Users/wes/facetalkcordova/platforms/android/app/src/main/java/com/gae/scaffolder/plugin/FCMPlugin.java:12: error: cannot find symbol
import com.google.firebase.iid.FirebaseInstanceId;
                              ^
  symbol:   class FirebaseInstanceId
  location: package com.google.firebase.iid